### PR TITLE
Add Assert points function & cleanup duplicate methods (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Created functions to test point geometries in VectorTester (@nkorinek, #176)
 * made `assert_string_contains()` accept correct strings with spaces in them (@nkorinek, #182)
 * added contributors file and updated README to remove that information (@nkorinek, #121)
 

--- a/matplotcheck/tests/test_vector.py
+++ b/matplotcheck/tests/test_vector.py
@@ -20,6 +20,31 @@ def poly_geo_plot(basic_polygon_gdf):
     return VectorTester(axis)
 
 
+@pytest.fixture
+def point_geo_plot(pd_gdf):
+    """Create a point plot for testing"""
+    _, ax = plt.subplots()
+
+    pd_gdf.plot(ax=ax)
+    ax.set_title("My Plot Title", fontsize=30)
+    ax.set_xlabel("x label")
+    ax.set_ylabel("y label")
+
+    axis = plt.gca()
+
+    return VectorTester(axis)
+
+
+@pytest.fixture
+def bad_pd_gdf(pd_gdf):
+    """Create a point geodataframe with slightly wrong values for testing"""
+    return gpd.GeoDataFrame(
+        geometry=gpd.points_from_xy(
+            pd_gdf.geometry.x + 1, pd_gdf.geometry.y + 1
+        )
+    )
+
+
 def test_list_of_polygons_check(poly_geo_plot, basic_polygon):
     """Check that the polygon assert works with a list of polygons."""
     x, y = basic_polygon.exterior.coords.xy
@@ -85,3 +110,38 @@ def test_polygon_custom_fail_message(poly_geo_plot, basic_polygon):
         poly_list = [(x[0] + 0.5, x[1]) for x in list(zip(x, y))]
         poly_geo_plot.assert_polygons(poly_list, m="Test Message")
         plt.close()
+
+
+def test_point_geometry_pass(point_geo_plot, pd_gdf):
+    """Check that the point geometry test recognizes correct points."""
+    point_geo_plot.assert_points(points_expected=pd_gdf)
+
+
+def test_point_geometry_fail(point_geo_plot, bad_pd_gdf):
+    """Check that the point geometry test recognizes incorrect points."""
+    with pytest.raises(AssertionError, match="Incorrect Point Data"):
+        point_geo_plot.assert_points(points_expected=bad_pd_gdf)
+
+
+def test_assert_point_fails_list(point_geo_plot, pd_gdf):
+    """
+    Check that the point geometry test fails anything that's not a
+    GeoDataFrame
+    """
+    list_geo = [list(pd_gdf.geometry.x), list(pd_gdf.geometry.y)]
+    with pytest.raises(ValueError, match="points_expected is not expected"):
+        point_geo_plot.assert_points(points_expected=list_geo)
+
+
+def test_get_points(point_geo_plot, pd_gdf):
+    """Tests that get_points returns correct values"""
+    xy_values = point_geo_plot.get_points()
+    assert list(sorted(xy_values.x)) == sorted(list(pd_gdf.geometry.x))
+    assert list(sorted(xy_values.y)) == sorted(list(pd_gdf.geometry.y))
+
+
+def test_assert_points_custom_message(point_geo_plot, bad_pd_gdf):
+    """Tests that a custom error message is passed."""
+    message = "Test message"
+    with pytest.raises(AssertionError, match="Test message"):
+        point_geo_plot.assert_points(points_expected=bad_pd_gdf, m=message)


### PR DESCRIPTION
* Added a get_points() and assert_points() function to the vector tester.

* Added in get_points() and assert_points() functions with tests

* Added proper documentation

* Small fix to please codacy

* black

* Updated changelog

* Rough draft for bug fix

* Fixed bug with multiple geometries plotted alongside bug with identical x values causing failure!

* typo

* Fixed small bug with markersize

* Added comments explaining code

* Taking out redundant tests

* Typo

* Fixing how vector checks for truth value of a dataframe