### PR TITLE
Title assert accepts strings (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Made `assert_string_contains()` accept a string instead of a list (@nkorinek, #53)
 * Added functions to get and assert the midpoint values of bins in a histogram (@nkorinek, #184)
 * Created tests for the autograde module (@nkorinek, #105)
 * Created tests for the vector module (@nkorinek, #209)

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -123,6 +123,10 @@ class PlotTester(object):
             return
 
         string = string.lower().replace(" ", "")
+
+        if isinstance(strings_expected, str):
+            strings_expected = [strings_expected]
+
         for check in strings_expected:
             if isinstance(check, str):
                 if not check.lower().replace(" ", "") in string:

--- a/matplotcheck/tests/test_base_titles_captions.py
+++ b/matplotcheck/tests/test_base_titles_captions.py
@@ -54,6 +54,12 @@ def test_title_contains_axes_spaces(pt_line_plt):
     plt.close()
 
 
+def test_title_contains_axes_string(pt_line_plt):
+    """Check title_contains for axes title as a string, not a list"""
+    pt_line_plt.assert_title_contains("My Plot Title", title_type="axes")
+    plt.close()
+
+
 def test_title_contains_axes_badtext(pt_line_plt):
     """Check title_contains fails when given bad text"""
     with pytest.raises(


### PR DESCRIPTION
* Fixed assert_title_contains to take strings as well as lists

* Better implementation

* Changelog update

Co-authored-by: Leah Wasser <leah.wasser@colorado.edu>